### PR TITLE
kbuild: control extra pacman packages with PACMAN_EXTRAPACKAGES

### DIFF
--- a/scripts/Makefile.package
+++ b/scripts/Makefile.package
@@ -144,6 +144,8 @@ snap-pkg:
 # pacman-pkg
 # ---------------------------------------------------------------------------
 
+PACMAN_EXTRAPACKAGES ?= headers api-headers
+
 PHONY += pacman-pkg
 pacman-pkg:
 	@ln -srf $(srctree)/scripts/package/PKGBUILD $(objtree)/PKGBUILD

--- a/scripts/package/PKGBUILD
+++ b/scripts/package/PKGBUILD
@@ -3,10 +3,13 @@
 # Contributor: Jan Alexander Steffens (heftig) <heftig@archlinux.org>
 
 pkgbase=${PACMAN_PKGBASE:-linux-upstream}
-pkgname=("${pkgbase}" "${pkgbase}-api-headers")
-if grep -q CONFIG_MODULES=y include/config/auto.conf; then
-	pkgname+=("${pkgbase}-headers")
-fi
+pkgname=("${pkgbase}")
+
+_extrapackages=${PACMAN_EXTRAPACKAGES:-}
+for pkg in $_extrapackages; do
+	pkgname+=("${pkgbase}-${pkg}")
+done
+
 pkgver="${KERNELRELEASE//-/_}"
 # The PKGBUILD is evaluated multiple times.
 # Running scripts/build-version from here would introduce inconsistencies.


### PR DESCRIPTION
Introduce a new variable, PACMAN_EXTRAPACKAGES, in the Makefile.package to control the creation of additional packages by the pacman-pkg target.

The headers and api-headers packages will be included by default if PACMAN_EXTRAPACKAGES is not set. This changes the previous behavior where headers was conditionally included if CONFIG_MODULES=y. Now, this control is delegated to the user.

To disable extra packages, set PACMAN_EXTRAPACKAGES to an empty value:

make pacman-pkg PACMAN_EXTRAPACKAGES=

or

make pacman-pkg PACMAN_EXTRAPACKAGES=""